### PR TITLE
[feat] #4 - naver 제공 정보를 사용하기 위하여 entity 수정 및 기업 매출 컬럼 정수형 수정 

### DIFF
--- a/src/main/java/com/wooribound/domain/corporate/entity/Enterprise.java
+++ b/src/main/java/com/wooribound/domain/corporate/entity/Enterprise.java
@@ -49,7 +49,7 @@ public class Enterprise {
   private String ceoName;
 
   @Column(name = "revenue", length = 20, nullable = false)
-  private String revenue;
+  private Long revenue;
 
   @Column(name = "ent_addr", length = 200, nullable = false)
   private String entAddr;

--- a/src/main/java/com/wooribound/domain/individual/entity/Resume.java
+++ b/src/main/java/com/wooribound/domain/individual/entity/Resume.java
@@ -33,9 +33,6 @@ public class Resume {
     @Column(name = "user_img", nullable = false, length = 200)  // NOT NULL 제약 조건
     private String userImg;
 
-    @Column(name = "user_email", nullable = false, length = 50)  // NOT NULL 제약 조건
-    private String userEmail;
-
     @Column(name = "user_intro", nullable = false, length = 200)  // NOT NULL 제약 조건
     private String userIntro;}
 

--- a/src/main/java/com/wooribound/domain/individual/entity/WbUser.java
+++ b/src/main/java/com/wooribound/domain/individual/entity/WbUser.java
@@ -45,6 +45,9 @@ public class WbUser {
   @Column(name = "birth", nullable = false)  // NOT NULL 제약 조건
   private Date birth;
 
+  @Column(name = "email", nullable = false, length = 50)  // NOT NULL 제약 조건
+  private String email;
+
   @Column(name = "phone", nullable = false, length = 20)
   private String phone;
 


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 naver 제공 정보를 사용하기 위하여 entity 수정 및 기업 매출 컬럼 정수형 수정 입니다.

## 🔗 관련 이슈

- #4
## ✨ 변경 사항

- naver에서 제공하는 email정보를 사용하기 위한 수정
- wbuser 엔티티 email추가
- resume 엔티티 email삭제
- enterprise 엔티티 revenue 컬럼 Long타입으로 수정
## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

- 생일정보와 출생년도 정보는 naver에서 제공해주는 그대로 분리하려고 하다가 따로 저장하는게 오히려 database에서의 연산을 불가하게 만들기 때문에 application에서 Date형식으로 변환해서 저장하도록 하겠습니다.

