### PR TITLE
[feat] #35 - 지원공고 삭제 시, 알림 생성

### DIFF
--- a/src/main/java/com/wooribound/domain/jobposting/JobPostingRepository.java
+++ b/src/main/java/com/wooribound/domain/jobposting/JobPostingRepository.java
@@ -34,5 +34,6 @@ public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
     List<JobPostingDetailProjection> getMyJobPostings(@Param("entId") String entId);
 
     @Modifying
-    int deleteByPostId(Long postId);
+    @Query("UPDATE JobPosting jp SET jp.isDeleted = 'Y' WHERE jp.postId = :postId")
+    int updateIsDeletedByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/wooribound/domain/jobposting/Service/AdminJobPostingServiceImpl.java
+++ b/src/main/java/com/wooribound/domain/jobposting/Service/AdminJobPostingServiceImpl.java
@@ -5,7 +5,13 @@ import com.wooribound.domain.jobposting.dto.JobPostingDTO;
 import com.wooribound.domain.jobposting.dto.JobPostingDetailDTO;
 import com.wooribound.domain.jobposting.JobPosting;
 import com.wooribound.domain.jobposting.JobPostingRepository;
+import com.wooribound.domain.notification.Notification;
+import com.wooribound.domain.notification.NotificationRepository;
+import com.wooribound.domain.userapply.UserApply;
+import com.wooribound.domain.userapply.UserApplyRepository;
+import com.wooribound.global.constant.YN;
 import com.wooribound.global.exception.NoJobPostingException;
+import com.wooribound.global.exception.NoUserApplyException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,46 +23,56 @@ import java.util.stream.Collectors;
 public class AdminJobPostingServiceImpl implements AdminJobPostingService {
 
     private final JobPostingRepository jobPostingRepository;
+    private final UserApplyRepository userApplyRepository;
+    private final NotificationRepository notificationRepository;
 
     @Override
     public List<JobPostingDTO> getAllJobPostings(AdminJobPostingReqDTO adminJobPostingReqDTO) {
-        List<JobPosting> jobPostings = jobPostingRepository.findJobPostings(adminJobPostingReqDTO.getEntName(),
-                adminJobPostingReqDTO.getJobName(), adminJobPostingReqDTO.getAddrCity());
+        List<JobPosting> jobPostings = jobPostingRepository.findJobPostings(adminJobPostingReqDTO.getEntName(), adminJobPostingReqDTO.getJobName(), adminJobPostingReqDTO.getAddrCity());
 
-        return jobPostings.stream()
-                .map(job -> JobPostingDTO.builder()
-                        .jobPostingId(job.getPostId())
-                        .entName(job.getEnterprise().getEntName())
-                        .postTitle(job.getPostTitle())
-                        .endDate(job.getEndDate())
-                        .postState(job.getPostState())
-                        .entAddr1(job.getEnterprise().getEntAddr1())
-                        .build())
-                .collect(Collectors.toList());
+        return jobPostings.stream().map(job -> JobPostingDTO.builder().jobPostingId(job.getPostId()).entName(job.getEnterprise().getEntName()).postTitle(job.getPostTitle()).endDate(job.getEndDate()).postState(job.getPostState()).entAddr1(job.getEnterprise().getEntAddr1()).build()).collect(Collectors.toList());
     }
 
     @Override
     public JobPostingDetailDTO getJobPostingDetail(Long postId) {
         JobPosting jobPosting = jobPostingRepository.findJobPostingByPostId(postId);
 
-        return JobPostingDetailDTO.builder()
-                .postTitle(jobPosting.getPostTitle())
-                .entName(jobPosting.getEnterprise().getEntName())
-                .postImg(jobPosting.getPostImg())
-                .startDate(jobPosting.getStartDate())
-                .endDate(jobPosting.getEndDate())
-                .postState(jobPosting.getPostState())
-                .jobName(jobPosting.getJob().getJobName())
-                .entAddr1(jobPosting.getEnterprise().getEntAddr1())
-                .build();
+        return JobPostingDetailDTO.builder().postTitle(jobPosting.getPostTitle()).entName(jobPosting.getEnterprise().getEntName()).postImg(jobPosting.getPostImg()).startDate(jobPosting.getStartDate()).endDate(jobPosting.getEndDate()).postState(jobPosting.getPostState()).jobName(jobPosting.getJob().getJobName()).entAddr1(jobPosting.getEnterprise().getEntAddr1()).build();
     }
 
     @Override
     public String deleteJobPosting(Long postId) {
-        if (jobPostingRepository.deleteByPostId(postId) != 0) {
-            return postId + "번 채용공고를 성공적으로 삭제했습니다.";
+        JobPosting jobPosting = jobPostingRepository.findJobPostingByPostId(postId);
+
+        if (jobPostingRepository.updateIsDeletedByPostId(postId) != 0) {
+            try {
+                List<UserApply> userApplies = userApplyRepository.findUserApply(postId);
+
+                if (userApplies.isEmpty()) {
+                    throw new NoUserApplyException(postId);  // 지원자가 없을 경우 예외 던짐
+                }
+
+                for (UserApply userApply : userApplies) {
+                    Notification notification = Notification.builder()
+                            .wbUser(userApply.getWbUser())
+                            .userApply(userApply)
+                            .notice(userApply.getWbUser().getName() + "님께서 지원하신 " +
+                                    jobPosting.getEnterprise().getEntName() + " 기업의 " +
+                                    jobPosting.getPostTitle() + " 채용공고가 삭제되어 지원 취소 처리 되었습니다." +
+                                    "\n 불편을 드려 죄송합니다.")
+                            .isConfirmed(YN.N)
+                            .build();
+
+                    notificationRepository.save(notification);
+                }
+                int updatedCnt = userApplyRepository.cancelUserApplyByPostId(postId);
+
+                return postId + "번 채용공고를 성공적으로 삭제 처리했습니다.";
+            } catch (NoUserApplyException e) {
+                return "채용공고는 삭제되었지만, 해당 공고에 지원자가 없어 지원 취소 알림은 없습니다.";
+            }
         } else {
-            throw new NoJobPostingException(postId);
+            throw new NoJobPostingException(postId);  // 채용공고 삭제 실패 시 예외 처리
         }
     }
 }

--- a/src/main/java/com/wooribound/domain/userapply/UserApplyRepository.java
+++ b/src/main/java/com/wooribound/domain/userapply/UserApplyRepository.java
@@ -22,4 +22,14 @@ public interface UserApplyRepository extends JpaRepository<UserApply, Long> {
     @Query("UPDATE UserApply ua SET ua.result = :applyResult WHERE ua.applyId = :applyId")
     int setApplicantResult(@Param("applyId") int applyId,
                            @Param("applyResult") ApplyResult applyResult);
+
+    // 4. 지원 결과 대기 중인 지원현황 조회
+    @Query("SELECT ua FROM UserApply ua WHERE ua.jobPosting.postId = :postId AND ua.result = 'PENDING'")
+    List<UserApply> findUserApply(Long postId);
+
+    // 4 - 1. 지원 결과 취소로 업데이트
+    @Modifying
+    @Query("UPDATE UserApply ua SET ua.result = 'CANCELED' WHERE ua.jobPosting.postId = :postId AND ua.result = 'PENDING'")
+    int cancelUserApplyByPostId(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/wooribound/global/exception/NoUserApplyException.java
+++ b/src/main/java/com/wooribound/global/exception/NoUserApplyException.java
@@ -1,0 +1,11 @@
+package com.wooribound.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class NoUserApplyException extends RuntimeException {
+
+    public NoUserApplyException(Long postId) {
+        super("채용공고 " + postId + "에 대한 지원자가 없거나 지원 취소 처리에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/wooribound/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/wooribound/global/handler/GlobalExceptionHandler.java
@@ -1,14 +1,6 @@
 package com.wooribound.global.handler;
 
-import com.wooribound.global.exception.AuthenticationException;
-import com.wooribound.global.exception.NoJobException;
-import com.wooribound.global.exception.NoJobPostingException;
-import com.wooribound.global.exception.NoKnowhowException;
-import com.wooribound.global.exception.NoTokenException;
-import com.wooribound.global.exception.NoWbUserException;
-import com.wooribound.global.exception.SaveInterestingJobException;
-import com.wooribound.global.exception.UpdateUserInfoException;
-import com.wooribound.global.exception.SaveWorkHistoryException;
+import com.wooribound.global.exception.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -63,6 +55,9 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(500).body(e.getMessage());
   }
 
-
+  @ExceptionHandler(NoUserApplyException.class)
+  public  ResponseEntity<String> handleNoUserApplyException(NoUserApplyException e){
+    return ResponseEntity.status(500).body(e.getMessage());
+  }
 }
 


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 서비스 관리자 채용공고 관련 기능입니다.

## 🔗 관련 이슈

- #35 

## ✨ 변경 사항

- NoUserApplyException 추가
- 채용공고 삭제 시, job_posting 테이블의 is_deleted 컬럼 'Y'로 변경
- notification 테이블에 데이터 추가
- user_apply 테이블에서 지원현황 'CANCELED'로 변경

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보
