### PR TITLE
[feat] #35 -지혜 목록 조회 시, 경고 누적수에 따른 정렬 기능

### DIFF
--- a/src/main/java/com/wooribound/api/admin/controller/AdminKnowhowController.java
+++ b/src/main/java/com/wooribound/api/admin/controller/AdminKnowhowController.java
@@ -2,8 +2,8 @@ package com.wooribound.api.admin.controller;
 
 import com.wooribound.api.admin.dto.AdminKnowhowReqDTO;
 import com.wooribound.api.admin.facade.AdminKnowhowFacade;
-import com.wooribound.domain.knowhow.dto.KnowhowDTO;
-import com.wooribound.domain.knowhow.dto.KnowhowDetailDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,12 +16,12 @@ public class AdminKnowhowController {
     private final AdminKnowhowFacade adminKnowhowFacade;
 
     @GetMapping
-    public List<KnowhowDTO> getAllKnowhows(@ModelAttribute AdminKnowhowReqDTO adminKnowhowReqDTO) {
+    public List<AdminKnowhowDTO> getAllKnowhows(@ModelAttribute AdminKnowhowReqDTO adminKnowhowReqDTO) {
         return adminKnowhowFacade.getAllKnowhows(adminKnowhowReqDTO);
     }
 
     @GetMapping("/detail")
-    public KnowhowDetailDTO getKnowhowDetail(@RequestParam Long knowhowId) {
+    public AdminKnowhowDetailDTO getKnowhowDetail(@RequestParam Long knowhowId) {
         return adminKnowhowFacade.getKnowhowDetail(knowhowId);
     }
 

--- a/src/main/java/com/wooribound/api/admin/dto/AdminKnowhowReqDTO.java
+++ b/src/main/java/com/wooribound/api/admin/dto/AdminKnowhowReqDTO.java
@@ -10,4 +10,5 @@ import lombok.*;
 public class AdminKnowhowReqDTO {
     private String knowhowJob;
     private String knowhowTitle;
+    private String knowhowReport;
 }

--- a/src/main/java/com/wooribound/api/admin/facade/AdminKnowhowFacade.java
+++ b/src/main/java/com/wooribound/api/admin/facade/AdminKnowhowFacade.java
@@ -2,8 +2,8 @@ package com.wooribound.api.admin.facade;
 
 import com.wooribound.api.admin.dto.AdminKnowhowReqDTO;
 import com.wooribound.domain.knowhow.service.AdminKnowhowService;
-import com.wooribound.domain.knowhow.dto.KnowhowDTO;
-import com.wooribound.domain.knowhow.dto.KnowhowDetailDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +17,12 @@ public class AdminKnowhowFacade {
     private final AdminKnowhowService adminKnowhowService;
 
     @Transactional(readOnly = true)
-    public List<KnowhowDTO> getAllKnowhows(AdminKnowhowReqDTO adminKnowhowReqDTO) {
+    public List<AdminKnowhowDTO> getAllKnowhows(AdminKnowhowReqDTO adminKnowhowReqDTO) {
         return adminKnowhowService.getAllKnowhows(adminKnowhowReqDTO);
     }
 
     @Transactional(readOnly = true)
-    public KnowhowDetailDTO getKnowhowDetail(Long knowhowId) {
+    public AdminKnowhowDetailDTO getKnowhowDetail(Long knowhowId) {
         return adminKnowhowService.getKnowhowDetail(knowhowId);
     }
 

--- a/src/main/java/com/wooribound/domain/knowhow/Knowhow.java
+++ b/src/main/java/com/wooribound/domain/knowhow/Knowhow.java
@@ -1,11 +1,13 @@
 package com.wooribound.domain.knowhow;
 
+import com.wooribound.domain.knowhowreported.KnowhowReported;
 import com.wooribound.domain.wbuser.WbUser;
 import jakarta.persistence.*;
 
 import lombok.*;
 
 import java.util.Date;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -15,34 +17,36 @@ import java.util.Date;
 @AllArgsConstructor
 @Entity
 @SequenceGenerator(
-    name = "knowhow_seq_generator",
-    sequenceName = "knowhow_SEQ",
-    allocationSize = 1
+        name = "knowhow_seq_generator",
+        sequenceName = "knowhow_SEQ",
+        allocationSize = 1
 )
 public class Knowhow {
-  @Id
-  @GeneratedValue(
-      strategy = GenerationType.AUTO,
-      generator = "knowhow_seq_generator"
-  )
-  @Column(name = "knowhow_id")
-  private Long knowhowId;
+    @Id
+    @GeneratedValue(
+            strategy = GenerationType.AUTO,
+            generator = "knowhow_seq_generator"
+    )
+    @Column(name = "knowhow_id")
+    private Long knowhowId;
 
-  @Column(name = "knowhow_job", length = 30, nullable = false)
-  private String knowhowJob;
+    @Column(name = "knowhow_job", length = 30, nullable = false)
+    private String knowhowJob;
 
-  @Column(name = "knowhow_title", length = 100, nullable = false)
-  private String knowhowTitle;
+    @Column(name = "knowhow_title", length = 100, nullable = false)
+    private String knowhowTitle;
 
-  @Lob
-  @Column(name = "knowhow_content", nullable = false)
-  private String knowhowContent;
+    @Column(name = "knowhow_content", length = 4000, nullable = false)
+    private String knowhowContent;
 
-  @Column(name = "upload_date", nullable = false)
-  private Date uploadDate;
+    @Column(name = "upload_date", nullable = false)
+    private Date uploadDate;
 
-  @ManyToOne
-  @JoinColumn(name = "user_id", nullable = false)
-  private WbUser wbUser;
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private WbUser wbUser;
+
+    @OneToMany(mappedBy = "knowhow", fetch = FetchType.LAZY, cascade = CascadeType.ALL)  // cascade를 추가
+    private List<KnowhowReported> knowhowReportedList;
 }
 

--- a/src/main/java/com/wooribound/domain/knowhow/KnowhowRepository.java
+++ b/src/main/java/com/wooribound/domain/knowhow/KnowhowRepository.java
@@ -1,20 +1,63 @@
 package com.wooribound.domain.knowhow;
 
-import jakarta.transaction.Transactional;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDetailProjection;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface KnowhowRepository extends JpaRepository<Knowhow, Long> {
+    // 신고 횟수 기준으로 내림차순
+    @Query("SELECT k.knowhowId AS knowhowId, k.knowhowJob AS knowhowJob, " +
+            "k.knowhowTitle AS knowhowTitle, k.uploadDate AS uploadDate, " +
+            "COUNT(k_report) AS reportedCnt, k.wbUser.userId AS userId FROM Knowhow k " +
+            "LEFT JOIN KnowhowReported k_report ON k_report.knowhow = k " +
+            "WHERE (:knowhowTitle IS NULL OR k.knowhowTitle LIKE %:knowhowTitle%) " +
+            "AND (:knowhowJob IS NULL OR k.knowhowJob = :knowhowJob) " +
+            "GROUP BY k.knowhowId, k.knowhowJob, k.knowhowTitle, k.uploadDate, k.wbUser.userId " +
+            "ORDER BY reportedCnt DESC")
+    List<AdminKnowhowProjection> findAllWithReportedCntDesc(@Param("knowhowTitle") String knowhowTitle,
+                                                            @Param("knowhowJob") String knowhowJob);
 
-    @Query("SELECT k FROM Knowhow k WHERE k.knowhowJob LIKE %:knowhowJob% AND k.knowhowTitle LIKE %:knowhowTitle%")
-    List<Knowhow> findAll(@Param("knowhowJob") String knowhowJob, @Param("knowhowTitle") String knowhowTitle);
+    // 신고 횟수 기준으로 오름차순
+    @Query("SELECT k.knowhowId AS knowhowId, k.knowhowJob AS knowhowJob, " +
+            "k.knowhowTitle AS knowhowTitle, k.uploadDate AS uploadDate, " +
+            "COUNT(k_report) AS reportedCnt, k.wbUser.userId AS userId FROM Knowhow k " +
+            "LEFT JOIN KnowhowReported k_report ON k_report.knowhow = k " +
+            "WHERE (:knowhowTitle IS NULL OR k.knowhowTitle LIKE %:knowhowTitle%) " +
+            "AND (:knowhowJob IS NULL OR k.knowhowJob = :knowhowJob) " +
+            "GROUP BY k.knowhowId, k.knowhowJob, k.knowhowTitle, k.uploadDate, k.wbUser.userId " +
+            "ORDER BY reportedCnt ASC")
+    List<AdminKnowhowProjection> findAllWithReportedCntAsc(@Param("knowhowTitle") String knowhowTitle,
+                                                           @Param("knowhowJob") String knowhowJob);
 
-    Optional<Knowhow> findByKnowhowId(@Param("knowhowId") Long knowhowId);
+    // 업로드 날짜 기준 내림차순
+    @Query("SELECT k.knowhowId AS knowhowId, k.knowhowJob AS knowhowJob, " +
+            "k.knowhowTitle AS knowhowTitle, k.uploadDate AS uploadDate, " +
+            "COUNT(k_report) AS reportedCnt, k.wbUser.userId AS userId FROM Knowhow k " +
+            "LEFT JOIN KnowhowReported k_report ON k_report.knowhow = k " +
+            "WHERE (:knowhowTitle IS NULL OR k.knowhowTitle LIKE %:knowhowTitle%) " +
+            "AND (:knowhowJob IS NULL OR k.knowhowJob = :knowhowJob) " +
+            "GROUP BY k.knowhowId, k.knowhowJob, k.knowhowTitle, k.uploadDate, k.wbUser.userId " +
+            "ORDER BY k.uploadDate DESC")
+    List<AdminKnowhowProjection> findAllWithUploadDateDesc(@Param("knowhowTitle") String knowhowTitle,
+                                                           @Param("knowhowJob") String knowhowJob);
+
+    // 노하우 상세보기
+    @Query("SELECT k.knowhowId AS knowhowId, k.knowhowJob AS knowhowJob, " +
+            "k.knowhowTitle AS knowhowTitle, k.uploadDate AS uploadDate, " +
+            "k.knowhowContent AS knowhowContent, COUNT(k_report) AS reportedCnt, " +
+            "k.wbUser.userId AS userId FROM Knowhow k " +
+            "LEFT JOIN KnowhowReported k_report ON k_report.knowhow = k " +
+            "WHERE k.knowhowId = :knowhowId " +
+            "GROUP BY k.knowhowId, k.knowhowJob, k.knowhowTitle, k.uploadDate, k.knowhowContent, k.wbUser.userId")
+    Optional<AdminKnowhowDetailProjection> findByKnowhowId(@Param("knowhowId") Long knowhowId);
 
     @Modifying
     int deleteByKnowhowId(Long knowhowId);

--- a/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDTO.java
+++ b/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDTO.java
@@ -9,11 +9,11 @@ import java.util.Date;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class KnowhowDetailDTO {
+public class AdminKnowhowDTO {
     private Long knowhowId;
     private String userId;
     private String knowhowJob;
     private String knowhowTitle;
-    private String knowhowContent;
     private Date uploadDate;
+    private int reportedCnt;
 }

--- a/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDetailDTO.java
+++ b/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDetailDTO.java
@@ -9,9 +9,12 @@ import java.util.Date;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class KnowhowDTO {
+public class AdminKnowhowDetailDTO {
     private Long knowhowId;
+    private String userId;
     private String knowhowJob;
     private String knowhowTitle;
+    private String knowhowContent;
     private Date uploadDate;
+    private int reportedCnt;
 }

--- a/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDetailProjection.java
+++ b/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowDetailProjection.java
@@ -1,0 +1,20 @@
+package com.wooribound.domain.knowhow.dto;
+
+import java.util.Date;
+
+public interface AdminKnowhowDetailProjection {
+    Long getKnowhowId();
+
+    String getKnowhowJob();
+
+    String getUserId();
+
+    String getKnowhowTitle();
+
+    String getKnowhowContent();
+
+    Date getUploadDate();
+
+    Long getReportedCnt();
+}
+

--- a/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowProjection.java
+++ b/src/main/java/com/wooribound/domain/knowhow/dto/AdminKnowhowProjection.java
@@ -1,0 +1,18 @@
+package com.wooribound.domain.knowhow.dto;
+
+import java.util.Date;
+
+public interface AdminKnowhowProjection {
+    Long getKnowhowId();
+
+    String getKnowhowJob();
+
+    String getUserId();
+
+    String getKnowhowTitle();
+
+    Date getUploadDate();
+
+    Long getReportedCnt();
+}
+

--- a/src/main/java/com/wooribound/domain/knowhow/service/AdminKnowhowService.java
+++ b/src/main/java/com/wooribound/domain/knowhow/service/AdminKnowhowService.java
@@ -1,15 +1,15 @@
 package com.wooribound.domain.knowhow.service;
 
 import com.wooribound.api.admin.dto.AdminKnowhowReqDTO;
-import com.wooribound.domain.knowhow.dto.KnowhowDTO;
-import com.wooribound.domain.knowhow.dto.KnowhowDetailDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDTO;
+import com.wooribound.domain.knowhow.dto.AdminKnowhowDetailDTO;
 
 import java.util.List;
 
 public interface AdminKnowhowService {
-    List<KnowhowDTO> getAllKnowhows(AdminKnowhowReqDTO adminKnowhowDTO);
+    List<AdminKnowhowDTO> getAllKnowhows(AdminKnowhowReqDTO adminKnowhowDTO);
 
-    KnowhowDetailDTO getKnowhowDetail(Long knowhowId);
+    AdminKnowhowDetailDTO getKnowhowDetail(Long knowhowId);
 
     String deleteKnowhow(Long knowhowId);
 }

--- a/src/main/java/com/wooribound/domain/knowhowreported/KnowhowReported.java
+++ b/src/main/java/com/wooribound/domain/knowhowreported/KnowhowReported.java
@@ -1,0 +1,41 @@
+package com.wooribound.domain.knowhowreported;
+
+import com.wooribound.domain.knowhow.Knowhow;
+import com.wooribound.domain.wbuser.WbUser;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+@Builder
+@Table(name = "knowhow_reported")
+@AllArgsConstructor
+@Entity
+@SequenceGenerator(
+        name = "knowhow_reported_seq_generator",
+        sequenceName = "knowhow_reported_SEQ",
+        allocationSize = 1
+)
+public class KnowhowReported {
+    @Id
+    @GeneratedValue(
+            strategy = GenerationType.AUTO,
+            generator = "knowhow_reported_seq_generator"
+    )
+    @Column(name = "reported_id")
+    private Long reportedId;
+
+    @Column(name = "reported_date", nullable = false)
+    private Date reportedDate;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private WbUser wbUser;
+
+    @ManyToOne
+    @JoinColumn(name = "knowhow_id", nullable = false)
+    private Knowhow knowhow;
+}

--- a/src/main/java/com/wooribound/domain/knowhowreported/KnowhowReportedRepository.java
+++ b/src/main/java/com/wooribound/domain/knowhowreported/KnowhowReportedRepository.java
@@ -1,0 +1,8 @@
+package com.wooribound.domain.knowhowreported;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KnowhowReportedRepository extends JpaRepository<KnowhowReported, Long> {
+}

--- a/src/main/java/com/wooribound/domain/wbuser/WbUser.java
+++ b/src/main/java/com/wooribound/domain/wbuser/WbUser.java
@@ -2,6 +2,7 @@ package com.wooribound.domain.wbuser;
 
 import com.wooribound.domain.interestjob.InterestJob;
 import com.wooribound.domain.knowhow.Knowhow;
+import com.wooribound.domain.knowhowreported.KnowhowReported;
 import com.wooribound.domain.resume.Resume;
 import com.wooribound.domain.workhistory.WorkHistory;
 import com.wooribound.global.constant.Gender;
@@ -114,4 +115,7 @@ public class WbUser {
 
   @OneToMany(mappedBy = "wbUser", fetch = FetchType.LAZY)
   private List<Knowhow> knowhows;
+
+  @OneToMany(mappedBy = "wbUser", fetch = FetchType.LAZY)
+  private List<KnowhowReported> knowhowReportedList;
 }


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 서비스 관리자 지혜 관리 관련 기능입니다.

## 🔗 관련 이슈

- #35 

## ✨ 변경 사항

- knowhow_reported 엔터티 생성 및 연관된 테이블과 관계 매핑 (wb_user & knowhow)
- 경고 조회 시, 경고 누적 수에 따른 정렬 기능
- Projection Interface 추가 (경고 누적수 COUNT할 때, 사용됨)
- 지혜 삭제 시, 연관된 신고 내역도 함께 삭제 (CASCADE 설정)

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보
