### PR TITLE
[fix] #77 - 개인회원 이력서 조회 URL 수정

### DIFF
--- a/src/main/java/com/wooribound/api/admin/controller/AdminIndividualController.java
+++ b/src/main/java/com/wooribound/api/admin/controller/AdminIndividualController.java
@@ -5,10 +5,7 @@ import com.wooribound.api.admin.facade.AdminIndividualFacade;
 import com.wooribound.domain.resume.dto.ResumeDetailDTO;
 import com.wooribound.domain.wbuser.dto.AdminIndividualDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,7 +22,7 @@ public class AdminIndividualController {
     }
 
     @GetMapping("/detail")
-    public ResumeDetailDTO getWbUserResume(String userId) {
+    public ResumeDetailDTO getWbUserResume(@RequestParam String userId) {
         return adminIndividualFacade.getWbUserResume(userId);
     }
 }

--- a/src/main/java/com/wooribound/domain/resume/ResumeServiceImpl.java
+++ b/src/main/java/com/wooribound/domain/resume/ResumeServiceImpl.java
@@ -81,6 +81,7 @@ public class ResumeServiceImpl implements ResumeService {
                 .phone(resume.getWbUser().getPhone())
                 .addrCity(resume.getWbUser().getAddrCity())
                 .addrProvince(resume.getWbUser().getAddrProvince())
+                .userIntro(resume.getUserIntro())
                 .userImg(resume.getUserImg())
                 .resumeEmail(resume.getResumeEmail())
                 .jobList(jobs)


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 서비스 관리자 개인회원 이력서 조회 기능 수정입니다.

## 🔗 관련 이슈

- #77 

## ✨ 변경 사항

- 이력서 조회 메소드에서 파리미터 값 앞에 @RequestParam 추가
- 이력서 데이터 반환할 때, userIntro 값이 없어서 추가

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

