### PR TITLE
탈퇴한 유저의 로그인 시도 시 410에러 처리

### DIFF
--- a/src/main/java/com/wooribound/global/security/userdetail/enterprise/EnterpriseUserDetailService.java
+++ b/src/main/java/com/wooribound/global/security/userdetail/enterprise/EnterpriseUserDetailService.java
@@ -2,8 +2,12 @@ package com.wooribound.global.security.userdetail.enterprise;
 
 import com.wooribound.domain.enterprise.Enterprise;
 import com.wooribound.domain.enterprise.EnterpriseRepository;
+import com.wooribound.global.constant.YN;
+import com.wooribound.global.constant.YNP;
+import com.wooribound.global.exception.DeletedUserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -18,13 +22,22 @@ public class EnterpriseUserDetailService implements UserDetailsService {
   @Autowired
   private final EnterpriseRepository enterpriseUserRepository;
 
-
   @Override
   public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
     Enterprise enterpriseUser = enterpriseUserRepository.findById(userId)
         .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
 
-    return new EnterpriseUserDetail(enterpriseUser.getEntId(), enterpriseUser.getEntName(), enterpriseUser.getEntPwd(), List.of(() -> "ROLE_ENTERPRISE_USER"));
+    if (enterpriseUser.getIsDeleted() == YNP.Y) {
+      throw new AuthenticationServiceException("탈퇴한 기업 회원입니다.",
+          new DeletedUserException("탈퇴한 기업 회원입니다. 회원가입을 새로 진행해 주세요"));
+    }
+
+    return new EnterpriseUserDetail(
+        enterpriseUser.getEntId(),
+        enterpriseUser.getEntName(),
+        enterpriseUser.getEntPwd(),
+        List.of(() -> "ROLE_ENTERPRISE_USER")
+    );
   }
 }
 


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 탈퇴한 유저의 로그인 시도 시 410에러 처리 입니다.

## 🔗 관련 이슈

- #20 

## ✨ 변경 사항

- 탈퇴한 유저의 로그인 시도 시 410에러 처리

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 트러블 슈팅

### 탈퇴 회원 처리 해결 과정 정리

#### WbUserDetailService에서 예외 처리를 하고 있었다.

```java
if(existWbUser.get().getIsDeleted() == YN.Y) {
		throw new DeletedUserException("탈퇴한 유저입니다...")
}
```

### 1. 초기 시도 - GlobalExceptionHandler

처음에는 단순히 예외처리를 `@ExceptionHandler`로 잡으려 했음

302 : FOUND를 활용하여 리다이랙션 처리를 하려 했지만 해결 x

```java

@RestControllerAdvice
public class GlobalExceptionHandler {
    @ExceptionHandler(DeletedUserException.class)
    public ResponseEntity<Object> handleDeletedUserException(DeletedUserException e) {
        return ResponseEntity.status(HttpStatus.FOUND)
            .header("Location", "http://localhost:8080/deleted/user")
            .build();
    }
}

```

#### 실패 원인 발견

- Spring Security 필터 체인에서 발생한 예외는 `@ExceptionHandler`가 잡지 못함
- 필터가 DispatcherServlet 이전에 실행되기 때문
- OAuth2 로그인과 일반 로그인의 처리 방식이 달라야 함을 인지

### 2. WbUser (OAuth2) 해결 과정

#### 1차 시도: SecurityConfig OAuth2 설정

```java
java
Copy
.oauth2Login(oauth2 -> oauth2
    .failureHandler((request, response, exception) -> {
        if (exception.getCause() instanceof DeletedUserException) {
            response.sendRedirect("http://localhost:8080/deleted/user");
        }
    })
)

```

- 문제점: 예외를 찾지 못함
- OAuth2 인증 과정에서 발생하는 모든 예외는 `OAuth2AuthenticationException`으로 wrapping됨
- SecurityConfig의 failureHandler는 `OAuth2AuthenticationException`만 처리할 수 있

#### 2차 시도: SecurityConfig 예외 체인 처리

```java
java
Copy
.oauth2Login(oauth2 -> oauth2
    .failureHandler((request, response, exception) -> {
        if (exception instanceof OAuth2AuthenticationException) {
            Throwable authException = ((OAuth2AuthenticationException) exception).getCause();
            if (authException instanceof DeletedUserException) {
                response.sendRedirect("http://localhost:8080/deleted/user");
                return;
            }
        }
    })
)

```

- 성공: OAuth2 로그인 과정에서 발생하는`OAuth2AuthenticationException` 을 감지하고,  wrapping한 DeletedUserException을 꺼내는 방식으로 CustomException을 필터 체인중에 감지하여 리다이렉션으로 처리

### 처리 흐름

```

1. 네이버 로그인 요청
   ↓
2. OAuth2 인증 처리 (WbUserDetailService)
   ↓
3. 탈퇴 회원 확인
   ↓
4. DeletedUserException 발생
   ↓
5. OAuth2AuthenticationException으로 wrapping
   ↓
6. SecurityConfig의 failureHandler에서 감지
   ↓
7. 리다이렉션 처리

```

### 핵심 포인트

1. OAuth2 인증은 브라우저 기반 인증이므로 리다이렉션 사용 가능
2. 예외 체인을 통해 내부의 CustomException 추출
3. OAuth2AuthenticationException을 활용한 예외 wrapping
4. SecurityConfig에서 중앙 집중식 처리

이러한 방식으로 OAuth2 로그인에서 발생하는 탈퇴 회원 접근을 적절히 처리하고 사용자를 에러 페이지로 안내할 수 있다.

### Enterprise 로그인의 탈퇴 회원 처리 해결 과정

### 1. 첫 시도: 직접 DeletedUserException 발생

```java

@Override
public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
    Enterprise enterpriseUser = enterpriseUserRepository.findById(userId)
        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));

    if (enterpriseUser.getIsDeleted() == YNP.Y) {
        throw new DeletedUserException("탈퇴한 기업 회원입니다");// ❌ 실패
    }

    return new EnterpriseUserDetail(...);
}

```

#### 실패 원인

1. DaoAuthenticationProvider가 UserDetailsService에서 예상하는 예외:
    - UsernameNotFoundException
    - AccountStatusException
    - AuthenticationException 계열
2. DeletedUserException은 위 예외들과 관계가 없어서 인식되지 않음

### 2. 해결: AuthenticationServiceException으로 Wrapping

```java
java
Copy
@Override
public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
    Enterprise enterpriseUser = enterpriseUserRepository.findById(userId)
        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));

    if (enterpriseUser.getIsDeleted() == YNP.Y) {
        throw new AuthenticationServiceException("탈퇴한 기업 회원입니다.",// ✅ 성공
            new DeletedUserException("탈퇴한 기업 회원입니다. 회원가입을 새로 진행해 주세요"));
    }

    return new EnterpriseUserDetail(...);
}

```

#### CustomAuthenticationFilter에서 예외 체인 활용 하여 DeletedUserException 감지

```java
setAuthenticationFailureHandler((request, response, exception) -> {
 
    Throwable cause = exception.getCause();

    if (exception instanceof InternalAuthenticationServiceException ||
        exception instanceof AuthenticationServiceException) {

        Throwable rootCause = cause;  // cause를 시작점으로
        while (rootCause != null) {
            if (rootCause instanceof DeletedUserException) {

                response.setStatus(HttpServletResponse.SC_GONE);
                // ... 응답 처리
                return;
            }
            // 다음 cause로 이동
            rootCause = rootCause.getCause();
        }
    }
});

```

### 3. 리다이렉션 문제 해결

#### 문제 인식

- API 호출 기반의 로그인에서는 서버의 리다이렉션 응답을 브라우저가 직접 처리할 수 없음
- AJAX 요청에서 리다이렉션은 브라우저에서 자동으로 따라가지 않음

#### 해결 방법: HTTP 상태 코드 활용

```java
if (exception instanceof InternalAuthenticationServiceException ||
            exception instanceof AuthenticationServiceException) {

          // cause의 cause도 체크 (더 깊이 들어가서 체크)
          Throwable rootCause = cause;
          while (rootCause != null) {
            if (rootCause instanceof DeletedUserException) {
              System.out.println("CustomAuthenticationFilter에서 DeletedUserException 잡음");
              response.setStatus(HttpServletResponse.SC_GONE);
              return;
            }
            rootCause = rootCause.getCause();
          }
        }
```

#### 프론트엔드 처리

410 error 발생 시 인터셉터에서 감지하여 탈퇴회원 안내페이지로 리다이렉트

```jsx
    instance.interceptors.response.use(
        response => response,
        async error => {
            const originalRequest = error.config;
            console.log('Response error:', {
                status: error.response?.status,
                data: error.response?.data
            });

            // 삭제된 유저 처리 (410 상태 코드)
            if (error.status === 410) {
                console.log('Deleted user detected, redirecting to deleted user page');
                window.location.href = ROUTES.DELETED_USER_REDIRECT.path;
                return Promise.reject(error);
            }
            return Promise.reject(error);
        }
    );
```

### 과정 정리

```

1. 로그인 요청
   → CustomAuthenticationFilter
   → EnterpriseUserDetailService (탈퇴 여부 체크)
   → AuthenticationServiceException(DeletedUserException)
   → CustomAuthenticationFilter의 failureHandler
   → 410 상태 코드 응답
   → Axios 인터셉터
   → 프론트엔드 리다이렉션

```

### 핵심 포인트

1. Spring Security의 인증 체인을 이해하고 적절한 지점에서 예외 발생
2. 예외를 AuthenticationServiceException으로 wrapping하여 인식 가능하게 함
3. API 기반 인증에서는 리다이렉션 대신 상태 코드 활용
4. 프론트엔드에서 전역적으로 처리할 수 있는 인터셉터 활용

### 리다이렉트 완료되는 모습
![image](https://github.com/user-attachments/assets/39d8a721-3e45-4ceb-bcc6-1e2d89324cea)
