### PR TITLE
[chore] #35 - notification 엔터티에 생성일 컬럼 추가

### DIFF
--- a/src/main/java/com/wooribound/domain/jobposting/Service/AdminJobPostingServiceImpl.java
+++ b/src/main/java/com/wooribound/domain/jobposting/Service/AdminJobPostingServiceImpl.java
@@ -16,6 +16,7 @@ import com.wooribound.global.exception.NoUserApplyException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -62,6 +63,7 @@ public class AdminJobPostingServiceImpl implements AdminJobPostingService {
                                     jobPosting.getPostTitle() + " 채용공고가 삭제되어 지원 취소 처리 되었습니다." +
                                     "\n 불편을 드려 죄송합니다.")
                             .isConfirmed(YN.N)
+                            .createdAt(new Date())
                             .build();
 
                     notificationRepository.save(notification);

--- a/src/main/java/com/wooribound/domain/notification/Notification.java
+++ b/src/main/java/com/wooribound/domain/notification/Notification.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Date;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Setter
@@ -43,6 +45,9 @@ public class Notification {
     @Column(name = "is_confirmed", columnDefinition = "VARCHAR2(1) DEFAULT 'N'", nullable = false)
     @Enumerated(value = EnumType.STRING)
     private YN isConfirmed;
+
+    @Column(name = "created_at", nullable = false)
+    private Date createdAt;
 
     @OneToOne
     @JoinColumn(name = "apply_id")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -74,12 +74,11 @@ INSERT INTO resume (resume_id, user_id, user_img, resume_email, user_intro) VALU
     (1, 'USER001', 'https://example.com/image1.jpg', 'user1@example.com', 'Experienced software developer with a strong background in Java and Spring.');
 
 -- 알림
-INSERT INTO notification (noti_id, user_id, apply_id, notice, is_confirmed)
-VALUES (1, 'USER001', 1, '축하합니다. 지원하신 공고에 합격하셨습니다.', 'N');
+INSERT INTO notification (noti_id, user_id, apply_id, notice, is_confirmed, created_at)
+VALUES (1, 'USER001', 1, '축하합니다. 지원하신 공고에 합격하셨습니다.', 'N', CURRENT_DATE);
 
-INSERT INTO notification (noti_id, user_id, apply_id, notice, is_confirmed)
-VALUES (2, 'USER002', 2, '지원하신 공고가 삭제되었습니다.', 'N');
-
+INSERT INTO notification (noti_id, user_id, apply_id, notice, is_confirmed, created_at)
+VALUES (2, 'USER002', 2, '지원하신 공고가 삭제되었습니다.', 'N', CURRENT_DATE);
 
 INSERT INTO admin (admin_id, admin_name, admin_pw, admin_type)
 VALUES (


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 notification 엔터티 변경입니다.

## 🔗 관련 이슈

- #35 

## ✨ 변경 사항

- notification 테이블에 컬럼 추가
- 알림 생성 시, 생성일 데이터도 추가
- data.sql 쿼리문 수정 

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

