### PR TITLE
[fix] #77 - 채용공고 목록 조회시, 삭제처리된 건 제외

### DIFF
--- a/src/main/java/com/wooribound/api/individual/controller/WbUserJobPostingController.java
+++ b/src/main/java/com/wooribound/api/individual/controller/WbUserJobPostingController.java
@@ -61,8 +61,8 @@ public class WbUserJobPostingController {
 
     // 3. 공고 상세 조회
     @GetMapping("/detail")
-    public JobPostingDetailDTO getJobPostingDetail(@RequestParam Long post_id) {
-        return wbUserJobPostingFacade.getJobPostingDetail(post_id);
+    public JobPostingDetailDTO getJobPostingDetail(@RequestParam Long postId) {
+        return wbUserJobPostingFacade.getJobPostingDetail(postId);
     }
 
 

--- a/src/main/java/com/wooribound/domain/jobposting/JobPostingRepository.java
+++ b/src/main/java/com/wooribound/domain/jobposting/JobPostingRepository.java
@@ -33,9 +33,10 @@ public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
             "WHEN jp.endDate < CURRENT_DATE THEN 'CLOSED' " +
             "END) AS postState " +
             "FROM JobPosting jp WHERE " +
-            "(:entName IS NULL OR jp.enterprise.entName = :entName) AND " +
+            "(:entName IS NULL OR jp.enterprise.entName LIKE %:entName%) AND " +
             "(:jobName IS NULL OR jp.job.jobName = :jobName) AND " +
-            "(:entAddr1 IS NULL OR jp.enterprise.entAddr1 = :entAddr1)")
+            "(:entAddr1 IS NULL OR jp.enterprise.entAddr1 = :entAddr1) AND " +
+            "(jp.isDeleted = 'N')")
     List<JobPostingProjection> findJobPostings(@Param("entName") String entName,
                                                @Param("jobName") String jobName,
                                                @Param("entAddr1") String entAddr1);
@@ -65,7 +66,6 @@ public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
             "(:interestJobs IS NULL OR jp.job.jobName IN :interestJobs)")
     List<JobPostingProjection> findJobPostingsNew(@Param("exJobs") List<String> exJobs,
                                                   @Param("interestJobs") List<String> interestJobs);
-
 
     // 2. 공고 상세 조회
     JobPosting findJobPostingByPostId(@Param("postId") Long postId);


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 채용공고 목록 기능입니다.

## 🔗 관련 이슈

- #77 

## ✨ 변경 사항

- 채용공고에서 기업명 검색할 때, 쿼리문 LIKE 사용으로 변경
- 채용공고 목록 조회 시, 삭제 처리된 공고는 제외되도록 쿼리문 수정
- WbUserJobPostingController에서 getJobPostingDetail 메소드 파라미터 변수명 수정 (post_id -> postId)

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

