### PR TITLE
[feat] #137 - oauth 에서 어느 컨테이너에서 콜백이 되더라도 인증과정을 처리할 수 있도록 redis에 oauth request 저장

### DIFF
--- a/src/main/java/com/wooribound/global/config/RedisConfig.java
+++ b/src/main/java/com/wooribound/global/config/RedisConfig.java
@@ -9,11 +9,16 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-@EnableRedisRepositories
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.io.IOException;
+
 @Configuration
+@EnableRedisRepositories
 @RequiredArgsConstructor
-public class Redisconfig {
+public class RedisConfig {
   @Value("${spring.data.redis.host}")
   private String REDIS_HOST;
 
@@ -23,8 +28,7 @@ public class Redisconfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     RedisStandaloneConfiguration redisStandaloneConfiguration =
-        new RedisStandaloneConfiguration(REDIS_HOST, REDIS_PORT);
-
+            new RedisStandaloneConfiguration(REDIS_HOST, REDIS_PORT);
     return new LettuceConnectionFactory(redisStandaloneConfiguration);
   }
 
@@ -34,7 +38,17 @@ public class Redisconfig {
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     redisTemplate.setConnectionFactory(redisConnectionFactory());
-
     return redisTemplate;
+  }
+
+  @Bean
+  public RedisTemplate<String, OAuth2AuthorizationRequest> oauth2AuthorizationRequestRedisTemplate(
+          RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, OAuth2AuthorizationRequest> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new JdkSerializationRedisSerializer());
+    template.setHashValueSerializer(new JdkSerializationRedisSerializer());
+    return template;
   }
 }

--- a/src/main/java/com/wooribound/global/security/SecurityConfig.java
+++ b/src/main/java/com/wooribound/global/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.wooribound.global.security.userdetail.admin.AdminUserDetailService;
 import com.wooribound.global.security.userdetail.enterprise.EnterpriseUserDetailService;
 import com.wooribound.global.security.userdetail.wbuser.WbUserDetailService;
 import com.wooribound.global.util.JWTUtil;
+import com.wooribound.global.util.RedisOAuth2AuthorizationRequestRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
@@ -46,6 +47,7 @@ public class SecurityConfig {
   private final WbUserDetailService wbUserDetailService;
   private final AdminUserDetailService adminUserDetailService;
   private final EnterpriseUserDetailService enterpriseUserDetailService;
+  private final RedisOAuth2AuthorizationRequestRepository authorizationRequestRepository;
   @Value("${spring.data.targetIp}")
   private String TARGET_IP;
   @Value("${spring.data.targetPort}")
@@ -123,6 +125,9 @@ public class SecurityConfig {
         .addFilterAt(enterpriseLoginFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
         .oauth2Login(oauth2 -> oauth2
+            .authorizationEndpoint(authorization -> authorization
+                    .authorizationRequestRepository(authorizationRequestRepository)
+            )
             .successHandler(wbUserSuccessHandler)
             .failureHandler((request, response, exception) -> {
               if (exception instanceof OAuth2AuthenticationException) {

--- a/src/main/java/com/wooribound/global/security/successhandler/WbUserSuccessHandler.java
+++ b/src/main/java/com/wooribound/global/security/successhandler/WbUserSuccessHandler.java
@@ -64,7 +64,7 @@ public class WbUserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     // 응답
     String redirectUrl_oldUser = UriComponentsBuilder
         .fromUriString(protocol+"://"+TARGET_IP+":"+TARGET_PORT)
-        .fragment("accessToken=" + accessToken)  // Bearer 접두사 추가
+        .fragment("accessToken=" + accessToken)
         .build()
         .toUriString();
 

--- a/src/main/java/com/wooribound/global/util/RedisOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/wooribound/global/util/RedisOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,64 @@
+package com.wooribound.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private final RedisTemplate<String, OAuth2AuthorizationRequest> oauth2AuthorizationRequestRedisTemplate;
+    private static final String OAUTH2_AUTHORIZATION_REQUEST_PREFIX = "oauth2_auth_request:";
+    private static final int TIMEOUT = 10 * 60;
+
+    @Override
+    public void saveAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+
+        String state = authorizationRequest.getState();
+        oauth2AuthorizationRequestRedisTemplate.opsForValue().set(
+                OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state,
+                authorizationRequest,
+                TIMEOUT,
+                TimeUnit.SECONDS
+        );
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        String state = request.getParameter("state");
+        if (state == null) return null;
+
+        return oauth2AuthorizationRequestRedisTemplate.opsForValue()
+                .get(OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        String state = request.getParameter("state");
+        if (state == null) return null;
+
+        String key = OAUTH2_AUTHORIZATION_REQUEST_PREFIX + state;
+        OAuth2AuthorizationRequest auth = oauth2AuthorizationRequestRedisTemplate.opsForValue().get(key);
+        if (auth != null) {
+            oauth2AuthorizationRequestRedisTemplate.delete(key);
+        }
+        return auth;
+    }
+}
+


### PR DESCRIPTION
…h request 저장

## 📜 Pull Request 설명

이 PR은 oauth 에서 어느 컨테이너에서 콜백이 되더라도 인증과정을 처리할 수 있도록 redis에 oauth request 저장 입니다.

## 🔗 관련 이슈

- #137 

## ✨ 변경 사항

- Security config에서 이제 Oauth 인증 요청 상태를 메모리에 저장하지 않고 redis에 저장하여 여러 컨테이너에서 공유 할 수 있도록 수정
- redis에 oauth request를 저장하기 위하여 RedisConfig에  oauth2AuthorizationRequestRedisTemplate 추가
- oauth request를 저장 삭제와 같은 기능을 구현한 RedisOAuth2AuthorizationRequestRepository 추가

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

- [추가적인 정보 또는 주의 사항]

