### PR TITLE
[update] #143 - 기업회원의 개인회원 이력서 조회 API에서 이력서 테이블 없으면 우바테이블에서 내역 들고오도록 수정

### DIFF
--- a/src/main/java/com/wooribound/domain/resume/ResumeServiceImpl.java
+++ b/src/main/java/com/wooribound/domain/resume/ResumeServiceImpl.java
@@ -132,15 +132,31 @@ public class ResumeServiceImpl implements ResumeService {
     @Override
     @Transactional
     public ResumeDetailDTO getWbUserResume(String userId) {
-            WbUser byIdWbUser = wbUserRepository.findById(userId)
-                    .orElseThrow(() -> new NoWbUserException("해당 사용자 ID를 찾을 수 없습니다: " + userId));
+        WbUser byIdWbUser = wbUserRepository.findById(userId)
+                .orElseThrow(() -> new NoWbUserException("해당 사용자 ID를 찾을 수 없습니다: " + userId));
 
-            Resume resume = resumeRepository.findByUserId(userId).orElseThrow();
-            List<WorkHistory> workHistoryList = workHistoryRepository.findByUserId(userId);
+        List<WorkHistory> workHistoryList = workHistoryRepository.findByUserId(userId);
 
-            List<String> jobs = workHistoryList.stream()
-                    .map(workHistory -> workHistory.getJob().getJobName()) // jobName만 추출
-                    .collect(Collectors.toList());
+        List<String> jobs = workHistoryList.stream()
+                .map(workHistory -> workHistory.getJob().getJobName()) // jobName만 추출
+                .collect(Collectors.toList());
+
+            Resume resume = resumeRepository.findByUserId(userId)
+                    .orElse(null);
+
+            if (resume == null) {
+                return ResumeDetailDTO.builder()
+                        .userName(byIdWbUser.getName())
+                        .jobPoint(byIdWbUser.getJobPoint())
+                        .phone(byIdWbUser.getPhone())
+                        .addrCity(byIdWbUser.getAddrCity())
+                        .addrProvince(byIdWbUser.getAddrProvince())
+                        .userIntro("")
+                        .userImg("")
+                        .resumeEmail("")
+                        .jobList(jobs)
+                        .build();
+            }
 
             return ResumeDetailDTO.builder()
                     .userName(resume.getWbUser().getName())


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은  기업회원의 개인회원 이력서 조회 API에서 이력서 테이블 없으면 우바테이블에서 내역 들고오도록 수정 입니다.

## 🔗 관련 이슈

- #143 

## ✨ 변경 사항

- [변경된 내용 요약]
- [추가된 기능 또는 수정된 버그 목록]
- [기타 중요한 변경 사항]

## ✅ 확인 사항

- [ ] 코드가 정상적으로 작동하는지 확인했습니다.
- [ ] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

- [추가적인 정보 또는 주의 사항]

